### PR TITLE
better year handling when format does not contain year

### DIFF
--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -402,6 +402,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
         date {
           match => [ "message", "MMM dd HH:mm:ss" ]
           locale => "en"
+          timezone => "UTC"
         }
       }
     CONFIG
@@ -419,6 +420,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
         date {
           match => [ "message", "MMM dd HH:mm:ss" ]
           locale => "en"
+          timezone => "UTC"
         }
       }
     CONFIG


### PR DESCRIPTION
if the time format does not have year then:

* use local year if month is the same as current one
* use previous year if current month is January but event is December
* use next year if current month is December but event is January
* use local year otherwise

fixes #3 

has very little impact on formats that have year.
For year-less formats there's extra allocation overhead per event (Time.now, time parsing is no longer direct to long, has to go through 2 DateTime objects)

Performance impact for this change was not analyzed.