### PR TITLE
Fix timezone example

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -34,7 +34,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
   # and is not the platform default.
   # If this is not specified the platform default will be used.
   # Canonical ID is good as it takes care of daylight saving time for you
-  # For example, `America/Los_Angeles` or `Europe/France` are valid IDs.
+  # For example, `America/Los_Angeles` or `Europe/Paris` are valid IDs.
   config :timezone, :validate => :string
 
   # Specify a locale to be used for date parsing using either IETF-BCP47 or POSIX language tag.


### PR DESCRIPTION
A quite small issue :), but the 'Europe/France' timezone referenced by the documentation is not listed by the joda-time reference
The filter outputs the following error message: The datetime zone id 'Europe/France' is not recognised

The correct timezone should be 'Europe/Paris'