### PR TITLE
additional separators in ISO8601

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -138,7 +138,11 @@ class LogStash::Filters::Date < LogStash::Filters::Base
           #Fall back solution of almost ISO8601 date-time
           almostISOparsers = [
             org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSZ").getParser(),
-            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS").getParser()
+            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS").getParser(),
+            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss,SSSZ").getParser(),
+            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss,SSS").getParser(),
+            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss:SSSZ").getParser(),
+            org.joda.time.format.DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss:SSS").getParser()
           ].to_java(org.joda.time.format.DateTimeParser)
           joda_parser = org.joda.time.format.DateTimeFormatterBuilder.new.append( nil, almostISOparsers ).toFormatter()
           if @timezone


### PR DESCRIPTION
* enabling comma and colon as separator for seconds in ISO8601 parser