### PR TITLE
Remove duplicated timestamp data

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -277,7 +277,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
       # remove original / temporary value if everything was OK during the parsing
       # keep the original value if keep_original_value is set to true.
       if @keep_original_value
-        event["@metadata"][@target] = event[field]
+        event["@metadata"][field] = event[field]
       end
       event.remove(field) if event["tags"].nil?
     end # @parsers.each

--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -97,6 +97,10 @@ class LogStash::Filters::Date < LogStash::Filters::Base
   # case of a failure.
   config :tag_on_failure, :validate => :array, :default => ["_dateparsefailure"]
 
+  # Keep the original value as a temperary metadata field. This is useful during development
+  # and in case to need to the field for later calculations or debug issues.
+  config :keep_original_value, :validate => :boolean, :default => false
+
   # LOGSTASH-34
   DATEPATTERNS = %w{ y d H m s S }
 
@@ -271,6 +275,10 @@ class LogStash::Filters::Date < LogStash::Filters::Base
         end # begin
       end # fieldvalue.each
       # remove original / temporary value if everything was OK during the parsing
+      # keep the original value if keep_original_value is set to true.
+      if @keep_original_value
+        event["@metadata"][@target] = event[field]
+      end
       event.remove(field) if event["tags"].nil?
     end # @parsers.each
 

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -63,7 +63,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     times.each do |input, output|
       sample("mydate" => input) do
         begin
-          insist { subject["mydate"] } == input
           insist { subject["@timestamp"].time } == Time.iso8601(output).utc
         rescue
           #require "pry"; binding.pry
@@ -92,7 +91,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     }
     times.each do |input, output|
       sample("mydate" => input) do
-        insist { subject["mydate"] } == input
         insist { subject["@timestamp"].time } == Time.iso8601(output).utc
       end
     end # times.each
@@ -118,7 +116,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     }
     times.each do |input, output|
       sample("mydate" => input) do
-        insist { subject["mydate"] } == input
         insist { subject["@timestamp"].time } == Time.iso8601(output).utc
       end
     end # times.each
@@ -147,7 +144,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     #Support float values
     sample("mydate" => 1350414944.123456) do
-      insist { subject["mydate"] } == 1350414944.123456
       insist { subject["@timestamp"].time } == Time.iso8601("2012-10-16T12:15:44.123-07:00").utc
     end
 
@@ -180,7 +176,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     }
     times.each do |input, output|
       sample("mydate" => input) do
-        insist { subject["mydate"] } == input
         insist { subject["@timestamp"].time } == Time.iso8601(output)
       end
     end # times.each
@@ -250,7 +245,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     time = "2001-09-09T01:46:40.000Z"
 
     sample("mydate" => time) do
-      insist { subject["mydate"] } == time
       insist { subject["@timestamp"].time } == Time.iso8601(time).utc
     end
   end
@@ -351,7 +345,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     }
     times.each do |input, output|
       sample("mydate" => input) do
-        insist { subject["mydate"] } == input
         insist { subject["@timestamp"].time } == Time.iso8601(output).utc
       end
     end # times.each
@@ -375,7 +368,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     }
     times.each do |input, output|
       sample("mydate" => input, "mytz" => "America/Los_Angeles") do
-        insist { subject["mydate"] } == input
         insist { subject["@timestamp"].time } == Time.iso8601(output).utc
       end
     end # times.each

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -471,4 +471,40 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     #Restore default locale
     java.util.Locale.setDefault(default_locale)
   end
+
+  describe "keep original timestamp values" do
+
+    config <<-'CONFIG'
+      filter {
+        date {
+          match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+          locale => "en"
+          keep_original_value => true
+        }
+      }
+    CONFIG
+
+    sample("timestamp" => "25/Mar/2013:20:33:56 +0000") do
+      insist { subject["@metadata"]["timestamp"] } == "25/Mar/2013:20:33:56 +0000"
+      insist { subject["@timestamp"].time } == Time.iso8601("2013-03-25T20:33:56.000Z")
+    end
+  end
+
+  describe "not keeping the original timestamp values" do
+
+    config <<-'CONFIG'
+      filter {
+        date {
+          match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+          locale => "en"
+        }
+      }
+    CONFIG
+
+    sample("timestamp" => "25/Mar/2013:20:33:56 +0000") do
+      insist { subject["@metadata"]["timestamp"] }.nil?
+      insist { subject["@timestamp"].time } == Time.iso8601("2013-03-25T20:33:56.000Z")
+    end
+  end
+
 end


### PR DESCRIPTION
As stated in #24, usually there is just redundant data being stored with timestamps. 

This PR's aims to fix #24 by:
- Removing the original timestamp value in case of everything goes ok with the parsing.
- Adding an option to keep the original value as a metadata value, good for later computations, debugging, etc.
- Add test for this behaviours.
