### PR TITLE
Fix/java event

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -88,7 +88,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
 
   # Store the matching timestamp into the given target field.  If not provided,
   # default to updating the `@timestamp` field of the event.
-  config :target, :validate => :string, :default => "@timestamp"
+  config :target, :validate => :string, :default => LogStash::Event::TIMESTAMP
 
   # Append values to the `tags` field when there has been no
   # successful match
@@ -97,14 +97,12 @@ class LogStash::Filters::Date < LogStash::Filters::Base
   # LOGSTASH-34
   DATEPATTERNS = %w{ y d H m s S }
 
-  public
   def initialize(config = {})
     super
 
     @parsers = Hash.new { |h,k| h[k] = [] }
   end # def initialize
 
-  public
   def register
     require "java"
     if @match.length < 2
@@ -227,9 +225,6 @@ class LogStash::Filters::Date < LogStash::Filters::Base
     end
   end
 
-  # def register
-
-  public
   def filter(event)
     @logger.debug? && @logger.debug("Date filter: received event", :type => event["type"])
 
@@ -279,13 +274,12 @@ class LogStash::Filters::Date < LogStash::Filters::Base
           # Tag this event if we can't parse it. We can use this later to
           # reparse+reindex logs if we improve the patterns given.
           @tag_on_failure.each do |tag|
-            event["tags"] ||= []
-            event["tags"] << tag unless event["tags"].include?(tag)
+            event.tag(tag)
           end
-        end # begin
-      end # fieldvalue.each
-    end # @parsers.each
+        end
+      end
+    end
 
     return event
-  end # def filter
-end # class LogStash::Filters::Date
+  end
+end

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/date"
 
@@ -412,7 +414,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "Dec 31 23:59:00" do
       logstash_time = Time.utc(2014,1,1,00,30,50)
-      expect(Time).to receive(:now).twice.and_return(logstash_time)
+      expect(Time).to receive(:now).at_most(:twice).and_return(logstash_time)
       insist { subject["@timestamp"].year } == 2013
     end
   end
@@ -430,7 +432,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "Jan 01 01:00:00" do
       logstash_time = Time.utc(2013,12,31,23,59,50)
-      expect(Time).to receive(:now).twice.and_return(logstash_time)
+      expect(Time).to receive(:now).at_most(:twice).and_return(logstash_time)
       insist { subject["@timestamp"].year } == 2014
     end
   end


### PR DESCRIPTION
- cleanup code
- use `Event#tag` instead of the the previous way that assumed mutability of tag field
- relax spec for Java Event

relates to elastic/logstash#4264 and elastic/logstash#4191