### PR TITLE
Fix one test failing under Java 7

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -189,7 +189,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
               now = Time.now
               now_month = now.month
               result = joda_parser.parseDateTime(date)
-              event_month = result.month_of_year.get
+              event_month = result.getMonthOfYear
 
               if (event_month == now_month)
                 result.with_year(now.year)


### PR DESCRIPTION
The problem is that Joda's DateTime object has two methods with similar
names: `monthOfYear()` and `getMonthOfYear`. JRuby provides some
method-renaming help to smooth the ruby/java naming conventions such
that an accessor method in Java named `getFooBar` will be available in
JRuby as `foo_bar`.

In the previous code, we used this to call `month_of_year`. However,
there is ambiguity here in that monthOfYear and getMonthOfYear are
candidates for snake-case method named `month_of_year` and it appears
that under Java 8 will call monthOfYear but under Java 7 will call
getMonthOfYear. THis matters because monthOfYear returns a
DateTime::Property, while getMonthOfYear returns an int.

Since we want an int, anyway, I explicitly invoke getMonthOfYear. The
failing spec now passes.

