### PR TITLE
    This test was failling when run inside the logstash test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.1
+  - Fix an issue with the expectation on `Time.now` and running the tests inside Logstash #52
 ## 2.1.0
  - New year rollover should be handled better now when a year is not present in
    the time format. If local time is December, and event time is January, the

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '2.1.0'
+  s.version         = '2.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The date filter is used for parsing dates from fields, and then using that date or timestamp as the logstash timestamp for the event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -414,7 +414,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "Dec 31 23:59:00" do
       logstash_time = Time.utc(2014,1,1,00,30,50)
-      expect(Time).to receive(:now).at_most(:twice).and_return(logstash_time)
+      expect(Time).to receive(:now).at_least(:twice).and_return(logstash_time)
       insist { subject["@timestamp"].year } == 2013
     end
   end
@@ -432,7 +432,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "Jan 01 01:00:00" do
       logstash_time = Time.utc(2013,12,31,23,59,50)
-      expect(Time).to receive(:now).at_most(:twice).and_return(logstash_time)
+      expect(Time).to receive(:now).at_least(:twice).and_return(logstash_time)
       insist { subject["@timestamp"].year } == 2014
     end
   end


### PR DESCRIPTION
This test was failling when run inside the logstash test.

We were explicitely defining a set amount of calls to `Time.now` (2), but
when we are testing this plugin inside logstash we are doing one more call to `Time`
inside the `Stud.stoppable_sleep` method to adjust the sleep to the skew
of the clock. This PR changes the expectation to `at_least` instead of
`at_most`. The real problem rely in the fact that this plugin uses a
configured pipeline to do the actual testing but this should be
refactored into a simple unit test.

Fixes #52