### PR TITLE
less reliance on event implementation for specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.2
+  - Make tests less reliant on implementation details of LogStash::Event
 ## 2.1.1
   - Fix an issue with the expectation on `Time.now` and running the tests inside Logstash #52
 ## 2.1.0

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '2.1.1'
+  s.version         = '2.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The date filter is used for parsing dates from fields, and then using that date or timestamp as the logstash timestamp for the event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -412,9 +412,12 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
       }
     CONFIG
 
-    sample "Dec 31 23:59:00" do
+    before(:each) do
       logstash_time = Time.utc(2014,1,1,00,30,50)
-      expect(Time).to receive(:now).at_least(:twice).and_return(logstash_time)
+      allow(Time).to receive(:now).and_return(logstash_time)
+    end
+
+    sample "Dec 31 23:59:00" do
       insist { subject["@timestamp"].year } == 2013
     end
   end
@@ -430,9 +433,12 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
       }
     CONFIG
 
-    sample "Jan 01 01:00:00" do
+    before(:each) do
       logstash_time = Time.utc(2013,12,31,23,59,50)
-      expect(Time).to receive(:now).at_least(:twice).and_return(logstash_time)
+      allow(Time).to receive(:now).and_return(logstash_time)
+    end
+
+    sample "Jan 01 01:00:00" do
       insist { subject["@timestamp"].year } == 2014
     end
   end


### PR DESCRIPTION
no longer rely on the exact number of times the event implementation will call Time.now as it is irrelevant

testing with logstash-core and logstash-core-event-java will show that this PR is necessary to pass all tests:

gem "logstash-core", :path => "/tmp/logstash/logstash-core"
gem "logstash-core-event-java", :path => "/tmp/logstash/logstash-core-event-java"