### PR TITLE
Fix default year parser for #62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.1.6
+  - bugfix: Fails to parse a timestamp without year that falls in DST switchover for CET #63 (fix for #62)
 # 2.1.5
   - doc: Include formatting syntax documentation in match config #60 (fix for #38)
   - internal: correct dependencies scope

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '2.1.5'
+  s.version         = '2.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The date filter is used for parsing dates from fields, and then using that date or timestamp as the logstash timestamp for the event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
As reported in #62, the default year handling parser has a different behavior than Joda standard parser.
As mentionned in http://joda-time.sourceforge.net/faq.html#illegalinstant *parseLocalDateTime* must be preferred when no timezone is present in the string and converted back to a dateTime.