### PR TITLE
Adding UNIX_AUTODETECT option

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -256,6 +256,11 @@ class LogStash::Filters::Date < LogStash::Filters::Base
             raise "Invalid UNIX epoch value '#{date}'" unless /^\d+$/ === date || date.is_a?(Numeric)
             date.to_i
           end
+        when "UNIX_AUTODETECT" # determine s or ms based on date passed in
+          parsers << lambda do |date|
+            raise "Invalid UNIX epoch value '#{date}'" unless /^\d+(?:\.\d+)?$/ === date || date.is_a?(Numeric)
+            date.to_i.to_s.length > 12 ? date.to_i : (date.to_f * 1000).to_i
+          end
         when "TAI64N" # TAI64 with nanoseconds, -10000 accounts for leap seconds
           parsers << lambda do |date|
             # Skip leading "@" if it is present (common in tai64n times)

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -191,6 +191,40 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     end # times.each
   end
 
+  describe "parsing with UNIX_AUTODETECT" do
+    config <<-CONFIG
+      filter {
+        date {
+          match => [ "mydate", "UNIX_AUTODETECT" ]
+          locale => "en"
+        }
+      }
+    CONFIG
+
+    times = {
+      "0"          => "1970-01-01T00:00:00.000Z",
+      "1000000000123" => "2001-09-09T01:46:40.123Z",
+      "1000000000" => "2001-09-09T01:46:40.000Z",
+      "1478207457456" => "2016-11-03T21:10:57.456Z",
+      "1478207457" => "2016-11-03T21:10:57.000Z",
+      "1478207457.456" => "2016-11-03T21:10:57.456Z",
+
+      # LOGSTASH-279 - sometimes the field is a number.
+      0          => "1970-01-01T00:00:00.000Z",
+      1000000000123 => "2001-09-09T01:46:40.123Z",
+      1000000000 => "2001-09-09T01:46:40.000Z",
+      1478207457456 => "2016-11-03T21:10:57.456Z",
+      1478207457 => "2016-11-03T21:10:57.000Z",
+      1478207457.456 => "2016-11-03T21:10:57.456Z",
+    }
+    times.each do |input, output|
+      sample("mydate" => input) do
+        insist { subject.get("mydate") } == input
+        insist { subject.get("@timestamp").time } == Time.iso8601(output)
+      end
+    end # times.each
+  end
+
   describe "failed parses should not cause a failure (LOGSTASH-641)" do
     config <<-'CONFIG'
       input {


### PR DESCRIPTION
Adding a UNIX_AUTODETECT option. Sometimes users pass in a mix of second timestamps and millisecond timestamps in the timestamp field and there isn't a good option to handle that case. 

For example, if a user passes in a MS timestamp meant for the UNIX timestamp matcher, then the parsed timestamp is really far into the future and invalid. Also the indices we create in Elasticsearch are based on date, so if a milliseconds timestamp is misinterpreted as a seconds timestamp, it will cause indices to be created very fast and potentially take down a cluster.

