### PR TITLE
Raising exception if UNIX timestamp is out of range

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -249,6 +249,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
         when "UNIX" # unix epoch
           parsers << lambda do |date|
             raise "Invalid UNIX epoch value '#{date}'" unless /^\d+(?:\.\d+)?$/ === date || date.is_a?(Numeric)
+            raise "Timestamp '#{date}' is out of range" if date.to_i > (2 ** 31) #The limit for signed ints 
             (date.to_f * 1000).to_i
           end
         when "UNIX_MS" # unix epoch in ms

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -191,6 +191,38 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     end # times.each
   end
 
+  describe "parsing with UNIX and UNIX_MS" do
+    config <<-CONFIG
+      filter {
+        date {
+          match => [ "mydate", "UNIX", "UNIX_MS" ]
+          locale => "en"
+        }
+      }
+    CONFIG
+
+    times = {
+      "0"          => "1970-01-01T00:00:00.000Z",
+      "1000000000" => "2001-09-09T01:46:40.000Z",
+      "1000000000123" => "2001-09-09T01:46:40.123Z",
+      "1478207457" => "2016-11-03T21:10:57.000Z",
+      "1478207457.456" => "2016-11-03T21:10:57.456Z",
+
+      # LOGSTASH-279 - sometimes the field is a number.
+      0          => "1970-01-01T00:00:00.000Z",
+      1000000000 => "2001-09-09T01:46:40.000Z",
+      1000000000123 => "2001-09-09T01:46:40.123Z",
+      1478207457 => "2016-11-03T21:10:57.000Z",
+      1478207457.456 => "2016-11-03T21:10:57.456Z",
+    }
+    times.each do |input, output|
+      sample("mydate" => input) do
+        insist { subject.get("mydate") } == input
+        insist { subject.get("@timestamp").time } == Time.iso8601(output)
+      end
+    end # times.each
+  end
+
   describe "failed parses should not cause a failure (LOGSTASH-641)" do
     config <<-'CONFIG'
       input {

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -116,10 +116,12 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     times = {
       "0"          => "1970-01-01T00:00:00.000Z",
       "1000000000" => "2001-09-09T01:46:40.000Z",
+      "1478207457" => "2016-11-03T21:10:57.000Z",
 
       # LOGSTASH-279 - sometimes the field is a number.
       0          => "1970-01-01T00:00:00.000Z",
-      1000000000 => "2001-09-09T01:46:40.000Z"
+      1000000000 => "2001-09-09T01:46:40.000Z",
+      1478207457 => "2016-11-03T21:10:57.000Z"
     }
     times.each do |input, output|
       sample("mydate" => input) do


### PR DESCRIPTION
Fix as discussed in https://github.com/logstash-plugins/logstash-filter-date/pull/72

