### PR TITLE
Add logstash-core jars as dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,11 @@ dependencies {
   testCompile group: "org.apache.logging.log4j", name: "log4j-core", version: "2.6.2"
   testCompile group: "joda-time", name: "joda-time", version: "2.9.4"
   testCompile group: 'org.jruby', name: 'jruby-complete', version: "1.7.26"
+  testCompile fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
   testCompile fileTree(dir: logstashCoreEventGemPath, include: '**/*.jar')
 
   compileOnly group: 'org.jruby', name: 'jruby-complete', version: "1.7.26"
+  compileOnly fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
   compileOnly fileTree(dir: logstashCoreEventGemPath, include: '**/*.jar')
 }
 


### PR DESCRIPTION
This fixes the following compilation error:


```
% ./gradlew assemble
...
:compileJava
/home/jls/projects/logstash-filter-date/src/main/java/org/logstash/filters/DateFilter.java:89: error: cannot access Queueable
            event.tag(t);
                 ^
```