### PR TITLE
Add support for BigDecimal as input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Fix bug where numbers from a JSON codec would result in a date parse failure. (#86, #89)
+
 ## 3.1.2
   - Docs: Fix date format used in examples
 

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The date filter is used for parsing dates from fields, and then using that date or timestamp as the logstash timestamp for the event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -166,6 +166,15 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
       insist { subject.get("mydate") } == "%{bad_value}"
       insist { subject.get("@timestamp") } != Time.iso8601("1970-01-01T00:00:00.000Z").utc
     end
+
+    # Regression test
+    # Support numeric values that come through the JSON parser. These numbers appear as BigDecimal 
+    # instead of Float.
+    sample(LogStash::Json.load('{ "mydate": 1350414944.123456 }')) do
+      insist { subject.get("mydate") } == 1350414944.123456
+      p subject.to_hash
+      insist { subject.get("@timestamp").time } == Time.iso8601("2012-10-16T12:15:44.123-07:00").utc
+    end
   end
 
   describe "parsing with UNIX_MS" do

--- a/src/main/java/org/logstash/filters/NumericParserExecutor.java
+++ b/src/main/java/org/logstash/filters/NumericParserExecutor.java
@@ -24,6 +24,7 @@ import org.logstash.Event;
 import org.logstash.filters.parser.TimestampParser;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 class NumericParserExecutor implements ParserExecutor {
   private TimestampParser parser;
@@ -40,6 +41,8 @@ class NumericParserExecutor implements ParserExecutor {
       return parser.parse(((Integer) input).longValue());
     } else if (input instanceof Double) {
       return parser.parse((Double) input);
+    } else if (input instanceof BigDecimal) {
+      return parser.parse((BigDecimal) input);
     } else {
       throw new IllegalArgumentException("Cannot parse date for value of type " + input.getClass().getName());
     }

--- a/src/main/java/org/logstash/filters/parser/CasualISO8601Parser.java
+++ b/src/main/java/org/logstash/filters/parser/CasualISO8601Parser.java
@@ -26,6 +26,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Arrays;
+import java.math.BigDecimal;
 
 /**
  * Created by jls on 11/2/16.
@@ -77,6 +78,11 @@ public class CasualISO8601Parser implements TimestampParser {
   @Override
   public Instant parse(Double value) {
     throw new IllegalArgumentException("Expected a string value, but got a double (" + value + "). Cannot parse date.");
+  }
+
+  @Override
+  public Instant parse(BigDecimal value) {
+    throw new IllegalArgumentException("Expected a string value, but got a bigdecimal (" + value + "). Cannot parse date.");
   }
 
   @Override

--- a/src/main/java/org/logstash/filters/parser/JodaParser.java
+++ b/src/main/java/org/logstash/filters/parser/JodaParser.java
@@ -24,6 +24,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Instant;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import java.math.BigDecimal;
 
 import java.util.Locale;
 
@@ -76,6 +77,11 @@ public class JodaParser implements TimestampParser {
   @Override
   public Instant parse(Double value) {
     throw new IllegalArgumentException("Expected a string value, but got a double (" + value + "). Cannot parse date.");
+  }
+
+  @Override
+  public Instant parse(BigDecimal value) {
+    throw new IllegalArgumentException("Expected a string value, but got a bigdecimal (" + value + "). Cannot parse date.");
   }
 
   @Override

--- a/src/main/java/org/logstash/filters/parser/TAI64NParser.java
+++ b/src/main/java/org/logstash/filters/parser/TAI64NParser.java
@@ -19,6 +19,7 @@
 
 package org.logstash.filters.parser;
 
+import java.math.BigDecimal;
 import org.joda.time.Instant;
 
 public class TAI64NParser implements TimestampParser {
@@ -50,6 +51,11 @@ public class TAI64NParser implements TimestampParser {
   @Override
   public Instant parse(Double value) {
     throw new IllegalArgumentException("Expected a string value, but got a double (" + value + "). Cannot parse date.");
+  }
+
+  @Override
+  public Instant parse(BigDecimal value) {
+    throw new IllegalArgumentException("Expected a string value, but got a bigdecimal (" + value + "). Cannot parse date.");
   }
 
   @Override

--- a/src/main/java/org/logstash/filters/parser/TimestampParser.java
+++ b/src/main/java/org/logstash/filters/parser/TimestampParser.java
@@ -20,10 +20,12 @@
 package org.logstash.filters.parser;
 
 import org.joda.time.Instant;
+import java.math.BigDecimal;
 
 public interface TimestampParser {
   Instant parse(String value);
   Instant parse(Long value);
   Instant parse(Double value);
+  Instant parse(BigDecimal value);
   Instant parseWithTimeZone(String value, String timezone);
 }

--- a/src/main/java/org/logstash/filters/parser/UnixEpochParser.java
+++ b/src/main/java/org/logstash/filters/parser/UnixEpochParser.java
@@ -1,5 +1,4 @@
-/*
- * Licensed to Elasticsearch under one or more contributor
+/* * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under
@@ -20,6 +19,7 @@
 package org.logstash.filters.parser;
 
 import org.joda.time.Instant;
+import java.math.BigDecimal;
 
 public class UnixEpochParser implements TimestampParser {
   private static long MAX_EPOCH_SECONDS = (long)Integer.MAX_VALUE;
@@ -74,5 +74,13 @@ public class UnixEpochParser implements TimestampParser {
       throw new IllegalArgumentException("Cannot parse date for value larger than UNIX epoch maximum seconds");
     }
     return value * 1000;
+  }
+
+  @Override
+  public Instant parse(BigDecimal value) {
+    if (value.longValue() > MAX_EPOCH_SECONDS) {
+      throw new IllegalArgumentException("Cannot parse date for value larger than UNIX epoch maximum seconds");
+    }
+    return new Instant(value.scaleByPowerOfTen(3).longValue());
   }
 }

--- a/src/main/java/org/logstash/filters/parser/UnixMillisEpochParser.java
+++ b/src/main/java/org/logstash/filters/parser/UnixMillisEpochParser.java
@@ -19,9 +19,11 @@
 
 package org.logstash.filters.parser;
 
+import java.math.BigDecimal;
 import org.joda.time.Instant;
 
 public class UnixMillisEpochParser implements TimestampParser {
+  private static long MAX_EPOCH_MILLISECONDS = (long)Integer.MAX_VALUE * 1000;
 
   @Override
   public Instant parse(String value) {
@@ -42,5 +44,14 @@ public class UnixMillisEpochParser implements TimestampParser {
   @Override
   public Instant parseWithTimeZone(String value, String timezone) {
     return parse(value);
+  }
+
+  @Override
+  public Instant parse(BigDecimal value) {
+    long lv = value.longValue();
+    if (lv > MAX_EPOCH_MILLISECONDS) {
+      throw new IllegalArgumentException("Cannot parse date for value larger than UNIX epoch maximum seconds");
+    }
+    return new Instant(lv);
   }
 }

--- a/src/test/java/org/logstash/filters/parser/UnixEpochParserTest.java
+++ b/src/test/java/org/logstash/filters/parser/UnixEpochParserTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import java.math.BigDecimal;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,6 +59,12 @@ public class UnixEpochParserTest {
   @Test
   public void parsesEpoch0() {
     Instant actual = new UnixEpochParser().parse(input);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void parsesEpochBigDecimal() {
+    Instant actual = new UnixEpochParser().parse(new BigDecimal(input));
     assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
This fixes a regression identified in #86 where numbers coming from JSON
codecs were parsed into BigDecimal values in Java. The date filter
didn't handle this class, so it was tagging it _dateparsefailure.

This commit adds a test for the reported case (json number -> date filter)
and fixes the regression.

Fixes #86

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
