### PR TITLE
ignore cancelled events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+  - Ignore cancelled events
+
 ## 3.1.4
   - Add metrics to track matches and failures
 

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.4'
+  s.version         = '3.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The date filter is used for parsing dates from fields, and then using that date or timestamp as the logstash timestamp for the event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/src/main/java/org/logstash/filters/DateFilter.java
+++ b/src/main/java/org/logstash/filters/DateFilter.java
@@ -75,10 +75,10 @@ public class DateFilter {
  public List<RubyEvent> receive(List<RubyEvent> rubyEvents) {
     for (RubyEvent rubyEvent : rubyEvents) {
       Event event = rubyEvent.getEvent();
-      // XXX: Check for cast failures
 
       switch (executeParsers(event)) {
         case FIELD_VALUE_IS_NULL_OR_FIELD_NOT_PRESENT:
+        case IGNORED:
           continue;
         case SUCCESS:
           if (successHandler != null) {
@@ -100,9 +100,9 @@ public class DateFilter {
 
   public ParseExecutionResult executeParsers(Event event) {
     Object input = event.getField(sourceField);
-    if (input == null) {
-      return ParseExecutionResult.FIELD_VALUE_IS_NULL_OR_FIELD_NOT_PRESENT;
-    }
+    if (event.isCancelled()) { return ParseExecutionResult.IGNORED; }
+    if (input == null) { return ParseExecutionResult.FIELD_VALUE_IS_NULL_OR_FIELD_NOT_PRESENT; }
+
     for (ParserExecutor executor : executors) {
       try {
         Instant instant = executor.execute(input, event);

--- a/src/main/java/org/logstash/filters/ParseExecutionResult.java
+++ b/src/main/java/org/logstash/filters/ParseExecutionResult.java
@@ -22,5 +22,6 @@ package org.logstash.filters;
 public enum ParseExecutionResult {
   SUCCESS,
   FAIL,
-  FIELD_VALUE_IS_NULL_OR_FIELD_NOT_PRESENT
+  FIELD_VALUE_IS_NULL_OR_FIELD_NOT_PRESENT,
+  IGNORED
 }

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -106,6 +106,19 @@ public class DateFilterTest {
         applyDouble(subject, 1478207457.456D, "2016-11-03T21:10:57.456Z");
     }
 
+    @Test
+    public void testCancelledEvent() throws Exception {
+        DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
+        subject.acceptFilterConfig("UNIX", loc, tz);
+
+        Event event = new Event();
+        event.cancel();
+        event.setField("[happened_at]", 1478207457.456D);
+
+        ParseExecutionResult code = subject.executeParsers(event);
+        Assert.assertSame(ParseExecutionResult.IGNORED, code);
+        Assert.assertNull(event.getField("[result_ts]"));
+    }
     private void applyString(DateFilter subject, String supplied, String expected) {
         Event event = new Event();
         event.setField("[happened_at]", supplied);


### PR DESCRIPTION
Fixes #90 

To benefit from performance improvement of the events list processing of the overridden `multi_filter` method which defers to the Java `DateFilter.receive()` method where it iterates through the passed events list, I think an acceptable solution is to simply ignore the cancelled events in the `DateFilter.receive()` loop. The returned events will include the original cancelled event but they will still keep their cancelled state so it should not have any impact downstream and at the same time not impact the DateFileter performance.