### PR TITLE
Fixes to for jruby 9K (tests pass on 1.7.25 too)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
 use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
 
 if Dir.exist?(logstash_path) && use_logstash_source
+  puts ">>>>>>>  Using supplied logstash-core source at: #{logstash_path}"
+
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
 use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
 
 if Dir.exist?(logstash_path) && use_logstash_source
-  puts ">>>>>>>  Using supplied logstash-core source at: #{logstash_path}"
-
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task :gradle => "gradle.properties" do
   system("./gradlew vendor")
 end
 
-file "gradle.properties" do
+task "gradle.properties" do
   delete_create_gradle_properties
 end
 


### PR DESCRIPTION
BTW - one must use the LOGSTASH_PATH and LOGSTASH_SOURCE with
logstash on the feature/9000 branch and gradle built.
Ran with and without TZ=UTC - all OK.

Fixes #102