### PR TITLE
Tests fix: Update to use Timestamp.toString since .toIso8601 was removed.

### DIFF
--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -206,7 +206,7 @@ public class DateFilterTest {
 
     private void commonAssertions(Event event, ParseExecutionResult code, String expected) {
         Assert.assertSame(ParseExecutionResult.SUCCESS, code);
-        String actual = ((Timestamp) event.getField("[result_ts]")).toIso8601();
+        String actual = ((Timestamp) event.getField("[result_ts]")).toString();
         Assert.assertTrue(String.format("Unequal - expected: %s, actual: %s", expected, actual), expected.equals(actual));
     }
 }


### PR DESCRIPTION
This only impacts the tests which are currently failing due to a missing toIso8601 method.