### PR TITLE
test fix: update from TimeStamp#toIso8601 to Timestamp#toString and bump to JRuby 9k for compile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ build
 .gradle
 
 # Intellij
-.idea
+.idea/*
 *.iml
 
 gradle.properties
+
+lib/logstash-filter-date_jars.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.10
+  - Build against JRuby 9k #116
+  - Fix build failure #114
+  
 ## 3.1.9
   - Update gemspec summary
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
   }
 
   dependencies {
-    classpath group: 'org.jruby', name: 'jruby-complete', version: "1.7.25"
+    classpath group: 'org.jruby', name: 'jruby-complete', version: "9.1.13.0"
   }
 }
 
@@ -59,10 +59,10 @@ dependencies {
   testCompile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   testCompile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
   testCompile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
-  testCompile group: 'org.jruby', name: 'jruby-complete', version: "1.7.25"
+  testCompile group: 'org.jruby', name: 'jruby-complete', version: "9.1.13.0"
   testCompile fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 
-  compileOnly group: 'org.jruby', name: 'jruby-complete', version: "1.7.25"
+  compileOnly group: 'org.jruby', name: 'jruby-complete', version: "9.1.13.0"
   compileOnly fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 }
 

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.9'
+  s.version         = '3.1.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -206,7 +206,7 @@ public class DateFilterTest {
 
     private void commonAssertions(Event event, ParseExecutionResult code, String expected) {
         Assert.assertSame(ParseExecutionResult.SUCCESS, code);
-        String actual = ((Timestamp) event.getField("[result_ts]")).toIso8601();
+        String actual = event.getField("[result_ts]").toString();
         Assert.assertTrue(String.format("Unequal - expected: %s, actual: %s", expected, actual), expected.equals(actual));
     }
 }


### PR DESCRIPTION
Fixes #114

Screen shot from the breaking upstream change (https://github.com/elastic/logstash/commit/d121c5818506fb1fba5203b8bcc14803a6c3a56c):

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/976291/33335742-843ce022-d433-11e7-87a7-096dd7381ff3.png">
