### PR TITLE
Log a debug message when parsing fails.

### DIFF
--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.10'
+  s.version         = '3.1.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/src/main/java/org/logstash/filters/NumericParserExecutor.java
+++ b/src/main/java/org/logstash/filters/NumericParserExecutor.java
@@ -28,8 +28,11 @@ import java.math.BigDecimal;
 
 class NumericParserExecutor implements ParserExecutor {
   private TimestampParser parser;
-  public NumericParserExecutor(TimestampParser parser) {
+  private String format;
+
+  public NumericParserExecutor(TimestampParser parser, String format) {
     this.parser = parser;
+    this.format = format;
   }
 
   public Instant execute(Object input, Event event) throws IOException {
@@ -46,5 +49,9 @@ class NumericParserExecutor implements ParserExecutor {
     } else {
       throw new IllegalArgumentException("Cannot parse date for value of type " + input.getClass().getName());
     }
+  }
+
+  public String toString() {
+    return this.format;
   }
 }

--- a/src/main/java/org/logstash/filters/TextParserExecutor.java
+++ b/src/main/java/org/logstash/filters/TextParserExecutor.java
@@ -27,8 +27,11 @@ import java.io.IOException;
 
 class TextParserExecutor implements ParserExecutor {
   private InputHandler handler;
+  private String format;
 
-  public TextParserExecutor(TimestampParser parser, String timeZone) {
+  public TextParserExecutor(TimestampParser parser, String timeZone, String format) {
+    this.format = format;
+
     if (timeZone != null && timeZone.contains("%{")) {
       this.handler = new DynamicTzInputHandler(parser, timeZone);
     } else {
@@ -45,5 +48,9 @@ class TextParserExecutor implements ParserExecutor {
 
   private Instant execute(String input, Event event) throws IOException {
     return this.handler.handle(input, event);
+  }
+
+  public String toString() {
+    return this.format;
   }
 }


### PR DESCRIPTION
This restores some behavior that was mistakenly removed in v3.0.0
(compared to v2.x) of this plugin.

The previous behavior (v2.x) would log a *warning* when all matches
failed.

This patch brings this behavior back with some slight modifications:

1) It does not use structured logging (because we don't have a simple
   way to do this in log4j2 yet, as compared to our ruby logging style)
2) It logs at debug level. In 2.x, it logged at warning.
3) All parse failures are logged. In 2.x, only the last match-failure
   was logged.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
