### PR TITLE
Build: review build to be more reliable/portable

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# This is intended to be run inside the docker container as the command of the docker-compose.
-
-env
-
-set -ex
-
-./gradlew test
-jruby -rbundler/setup -S rspec -fd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.15
+  - Build: review build to be more reliable/portable [#139](https://github.com/logstash-plugins/logstash-filter-date/pull/139)
+    * cleaned up Java dependencies 
+
 ## 3.1.14
   - Update log4j to 2.17.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,9 @@
-@files=[]
-
-task :default do
-  system("rake -T")
-end
-
-require "logstash/devutils/rake"
+require 'logstash/devutils/rake'
 
 task :vendor => :gradle
 
 task :gradle => "gradle.properties" do
-  system("./gradlew vendor")
+  sh("./gradlew clean vendor")
 end
 
 task "gradle.properties" do
@@ -28,3 +22,10 @@ def delete_create_gradle_properties
   puts `cat #{gradle_properties_file}`
 end
 
+task :test do
+  require 'rspec'
+  require 'rspec/core/runner'
+  Rake::Task[:vendor].invoke
+  sh './gradlew test'
+  exit(RSpec::Core::Runner.run(Rake::FileList['spec/**/*_spec.rb']))
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,10 @@
 require 'logstash/devutils/rake'
 
-task :vendor => :gradle
-
-task :gradle => "gradle.properties" do
-  sh("./gradlew clean vendor")
+task :vendor => "gradle.properties" do
+  sh "#{File.join(Dir.pwd, 'gradlew')} vendor"
 end
 
-task "gradle.properties" do
-  delete_create_gradle_properties
-end
-
-def delete_create_gradle_properties
+file "gradle.properties" do
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
   lsc_path = `bundle show logstash-core`
@@ -19,5 +13,5 @@ def delete_create_gradle_properties
     f.puts "logstashCoreGemPath=#{lsc_path}"
   end
   puts "-------------------> Wrote #{gradle_properties_file}"
-  puts `cat #{gradle_properties_file}`
+  puts File.read(gradle_properties_file)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'logstash/devutils/rake'
 
 task :vendor => "gradle.properties" do
-  sh "#{File.join(Dir.pwd, 'gradlew')} vendor"
+  sh "#{File.join(Dir.pwd, 'gradlew')} clean vendor"
 end
 
 file "gradle.properties" do

--- a/Rakefile
+++ b/Rakefile
@@ -21,11 +21,3 @@ def delete_create_gradle_properties
   puts "-------------------> Wrote #{gradle_properties_file}"
   puts `cat #{gradle_properties_file}`
 end
-
-task :test do
-  require 'rspec'
-  require 'rspec/core/runner'
-  Rake::Task[:vendor].invoke
-  sh './gradlew test'
-  exit(RSpec::Core::Runner.run(Rake::FileList['spec/**/*_spec.rb']))
-end

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,6 @@ dependencies {
   compileOnly group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
   compileOnly fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 
-  compileOnly 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-  compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
-  compileOnly 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
-
   testImplementation group: 'junit', name: 'junit', version: '4.12'
   testImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
   testImplementation group: "joda-time", name: "joda-time", version: "2.10.5"

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,10 @@ repositories {
 
 dependencies {
   compileOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
-  compileOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
   // Keep Joda version same as JRuby 9.2.20.1
   compileOnly group: "joda-time", name: "joda-time", version: "2.10.5"
+  compileOnly group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
+  compileOnly fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 
   compileOnly 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.7.4'

--- a/build.gradle
+++ b/build.gradle
@@ -46,26 +46,15 @@ repositories {
 
 dependencies {
   compileOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
-  compileOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
   // Keep Joda version same as JRuby 1.7.25 and 9.1.9.0
   compileOnly group: "joda-time", name: "joda-time", version: "2.8.2"
-
-  compileOnly 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-  compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
-  compileOnly 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
-
+  compileOnly group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
+  compileOnly fileTree(dir: logstashCoreGemPath, include: '**/logstash-core.jar')
   testImplementation group: 'junit', name: 'junit', version: '4.12'
-  testImplementation group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
   testImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
   testImplementation group: "joda-time", name: "joda-time", version: "2.8.2"
-  testImplementation 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
-  testImplementation 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
   testImplementation group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
   testImplementation fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
-
-  compileOnly group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
-  compileOnly fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 }
 
 task rubyBootstrap {

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.14'
+  s.version         = '3.1.15'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR does a few things:
- in case of a `gradle vendor` failure halts the build 
  https://github.com/elastic/logstash/issues/12869
- cleaned up Java dependencies - plugin did not really depend on everything listed
- aligned running Java/Ruby test using `rake test` ... depends on:
  https://github.com/elastic/logstash-devutils/pull/96
  https://github.com/logstash-plugins/.ci/pull/36
