### PR TITLE
Switched time string comparation to Timestamp comparable to avoiding problems due to precision loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 3.1.11
   - Fix: update to Gradle 7 [#140](https://github.com/logstash-plugins/logstash-filter-date/pull/140)
+  - Fix: Fix spec and unit tests after introduction of nanosecond precision in Logstash [#141](https://github.com/logstash-plugins/logstash-filter-date/pull/141)
 
 ## 3.1.10
   - Build against JRuby 9k #116

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.1.11
-  - Fix: update to Gradle 7 [#140](https://github.com/logstash-plugins/logstash-filter-date/pull/140)
-  - Fix: Fix spec and unit tests after introduction of nanosecond precision in Logstash [#141](https://github.com/logstash-plugins/logstash-filter-date/pull/141)
+## Unreleased
+  - Internal: upgrade packaging tooling to Gradle 7 so that plugin can be packaged on modern Java releases [#140](https://github.com/logstash-plugins/logstash-filter-date/pull/140)
+  - Internal: refined spec and unit test assertions to account for changes in how timestamps are serialised in Logstash 8. [#141](https://github.com/logstash-plugins/logstash-filter-date/pull/141)
 
 ## 3.1.10
   - Build against JRuby 9k #116

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.11'
+  s.version         = '3.1.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.1.10'
+  s.version         = '3.1.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-input-generator'
   s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-output-null'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '>= 2.3'
   s.add_development_dependency 'insist'
   s.add_development_dependency 'benchmark-ips'
 end

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -479,7 +479,17 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "2016 Mar 26 02:00:37" do
       insist { subject.get("tags") } != ["_dateparsefailure"]
-      insist { subject.get("@timestamp").to_s } == "2016-03-26T01:00:37.000Z"
+#       insist { subject.get("@timestamp").to_s } == "2016-03-26T01:00:37.000Z"
+      expect(subject.get("@timestamp")).to be_a_logstash_timestamp_equivalent_to("2016-03-26T01:00:37.000Z")
+    end
+  end
+
+  RSpec::Matchers.define :be_a_logstash_timestamp_equivalent_to do |expected|
+    expected = LogStash::Timestamp.new(expected) unless expected.kind_of?(LogStash::Timestamp)
+    description { "be a LogStash::Timestamp equivalent to #{expected}" }
+
+    match do |actual|
+      actual.kind_of?(LogStash::Timestamp) && actual == expected
     end
   end
 
@@ -571,7 +581,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
       sample "Mar 27 01:59:59" do
         expect(subject.get("tags")).to be_nil
-        expect(subject.get("@timestamp").to_s).to eq "2016-03-27T00:59:59.000Z"
+        expect(subject.get("@timestamp")).to be_a_logstash_timestamp_equivalent_to("2016-03-27T00:59:59.000Z")
       end
 
       sample "Mar 27 02:00:01" do
@@ -580,7 +590,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
       sample "Mar 27 03:00:01" do
         expect(subject.get("tags")).to be_nil
-        expect(subject.get("@timestamp").to_s).to eq "2016-03-27T01:00:01.000Z"
+        expect(subject.get("@timestamp")).to be_a_logstash_timestamp_equivalent_to("2016-03-27T01:00:01.000Z")
       end
     end
   end

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -483,15 +483,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     end
   end
 
-  RSpec::Matchers.define :be_a_logstash_timestamp_equivalent_to do |expected|
-    expected = LogStash::Timestamp.new(expected) unless expected.kind_of?(LogStash::Timestamp)
-    description { "be a LogStash::Timestamp equivalent to #{expected}" }
-
-    match do |actual|
-      actual.kind_of?(LogStash::Timestamp) && actual == expected
-    end
-  end
-
   context "Default year handling when parsing with timezone from event" do
 
     describe "LOGSTASH-34 - Default year should be this year" do

--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -479,7 +479,6 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
 
     sample "2016 Mar 26 02:00:37" do
       insist { subject.get("tags") } != ["_dateparsefailure"]
-#       insist { subject.get("@timestamp").to_s } == "2016-03-26T01:00:37.000Z"
       expect(subject.get("@timestamp")).to be_a_logstash_timestamp_equivalent_to("2016-03-26T01:00:37.000Z")
     end
   end

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -210,7 +210,5 @@ public class DateFilterTest {
         Assert.assertSame(ParseExecutionResult.SUCCESS, code);
         final Timestamp actual = (Timestamp) event.getField("[result_ts]");
         assertEquals(new Timestamp(expected), actual);
-//        String actual = event.getField("[result_ts]").toString();
-//        Assert.assertTrue(String.format("Unequal - expected: %s, actual: %s", expected, actual), expected.equals(actual));
     }
 }

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+
 public class DateFilterTest {
     private List<String> failtagList = Collections.singletonList("_date_parse_fail");
     private String tz = "UTC";
@@ -206,7 +208,9 @@ public class DateFilterTest {
 
     private void commonAssertions(Event event, ParseExecutionResult code, String expected) {
         Assert.assertSame(ParseExecutionResult.SUCCESS, code);
-        String actual = event.getField("[result_ts]").toString();
-        Assert.assertTrue(String.format("Unequal - expected: %s, actual: %s", expected, actual), expected.equals(actual));
+        final Timestamp actual = (Timestamp) event.getField("[result_ts]");
+        assertEquals(new Timestamp(expected), actual);
+//        String actual = event.getField("[result_ts]").toString();
+//        Assert.assertTrue(String.format("Unequal - expected: %s, actual: %s", expected, actual), expected.equals(actual));
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fix spec and unit tests after introduction of nanosecond precision in Logstash with https://github.com/elastic/logstash/pull/12797

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR switched time comparations in specs and unit test from String to `org.logstash.Timestamp` to avoid problems due to loss of precision.

The PR https://github.com/elastic/logstash/pull/12797 introduced nanosecond precision into Logstash, a similar problem happened also into [JDBC plugin](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/85) and here is implemented the same solution described in the [original comment](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/85#discussion_r737838793).

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It doesn't impact the user, it's only related to tests

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- run `./gradlew test` on a JDK 11

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
The problem could be seen at https://app.travis-ci.com/github/logstash-plugins/logstash-filter-date/jobs/545405353#L528

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
logstash_1_f52dffb2a8a0 | <=====--------> 42% EXECUTING [8s]> :compileTestJava<=====--------> 42% EXECUTING [9s]<===========--> 85% EXECUTING [9s]> :test<===========--> 85% EXECUTING [10s]<===========--> 85% EXECUTING [11s]<===========--> 85% EXECUTING [12s]> :test > Resolve files of :testRuntimeClasspath> :test > 0 tests completed<===========--> 85% EXECUTING [13s]> :test > Executing test org.logstash.filters.parser.JodaParserTest<===========--> 85% EXECUTING [14s]> :test > 2 tests completed> :test > Executing test org.logstash.filters.parser.UnixEpochParserTest> :test > 16 tests completed> :test > 162 tests completed> :test > 178 tests completed> :test > Executing test org.logstash.filters.DateFilterTest<===========--> 85% EXECUTING [15s]<===========--> 85% EXECUTING [16s]<===========--> 85% EXECUTING [17s]<===========--> 85% EXECUTING [18s]> :test > 180 tests completedlogstash_1_f52dffb2a8a0 | > Task :test
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testIsoStrings FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testUnixLongs FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testIsoStringsInterpolateTz FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testUnixInts FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | <===========--> 85% EXECUTING [18s]> :test > 186 tests completed, 4 failed> :test > Executing test org.logstash.filters.DateFilterTestlogstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testPatternStringsInterpolateTzNoYear FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | org.logstash.filters.DateFilterTest > testUnixStrings FAILED
logstash_1_f52dffb2a8a0 |     java.lang.AssertionError at DateFilterTest.java:210
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | <===========--> 85% EXECUTING [18s]> :test > 188 tests completed, 6 failedlogstash_1_f52dffb2a8a0 | 188 tests completed, 6 failed
loggstash_1_f52dffb2a8a0 | logstash_1_f52dffb2a8a0 | 
logstash_1_f52dffb2a8a0 | <===========--> 85% EXECUTING [19s]> :testlogstash_1_f52dffb2a8a0 | > Task :test FAILED
```
