### PR TITLE
Bump Joda-time to 2.10.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ repositories {
 dependencies {
   compileOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
   compileOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
-  // Keep Joda version same as JRuby 1.7.25 and 9.1.9.0
-  compileOnly group: "joda-time", name: "joda-time", version: "2.8.2"
+  // Keep Joda version same as JRuby 9.2.20.1
+  compileOnly 'joda-time:joda-time:2.10.5'
 
   compileOnly 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
@@ -57,7 +57,7 @@ dependencies {
   testImplementation group: 'junit', name: 'junit', version: '4.12'
   testImplementation group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
   testImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
-  testImplementation group: "joda-time", name: "joda-time", version: "2.8.2"
+  testImplementation 'joda-time:joda-time:2.10.5'
   testImplementation 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
   testImplementation 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   compileOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
   compileOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
   // Keep Joda version same as JRuby 9.2.20.1
-  compileOnly 'joda-time:joda-time:2.10.5'
+  compileOnly group: "joda-time", name: "joda-time", version: "2.10.5"
 
   compileOnly 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
@@ -57,7 +57,7 @@ dependencies {
   testImplementation group: 'junit', name: 'junit', version: '4.12'
   testImplementation group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
   testImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.1"
-  testImplementation 'joda-time:joda-time:2.10.5'
+  testImplementation group: "joda-time", name: "joda-time", version: "2.10.5"
   testImplementation 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
   testImplementation 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -69,28 +69,20 @@ public class DateFilterTest {
 
     @Test
     public void testIsoStringsInterpolateTz() throws Exception {
-//        Map<String, String> testElements = new HashMap<String, String>() {{
-//            put("2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z");
-//            put("1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z");
-//            put("2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z");
-//            // Venezuela changed from -4:00 to -4:30 in late 2007
-//            put("2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z");
-//            // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
-//            put("2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z");
-//        }};
+        Map<String, String> testElements = new HashMap<String, String>() {{
+            put("2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z");
+            put("1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z");
+            put("2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z");
+            // Venezuela changed from -4:00 to -4:30 in late 2007
+            put("2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z");
+            // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
+            put("2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z");
+        }};
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("ISO8601", loc, "%{mytz}");
-//        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-//            applyStringTz(subject, entry.getKey(), entry.getValue(), "America/Caracas");
-//        }
-        applyStringTz(subject, "2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z", "America/Caracas");
-        applyStringTz(subject, "1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z", "America/Caracas");
-        applyStringTz(subject, "2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z", "America/Caracas");
-        // Venezuela changed from -4:00 to -4:30 in late 2007
-        applyStringTz(subject, "2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z", "America/Caracas");
-        // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
-        applyStringTz(subject, "2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z", "America/Caracas");
-//        applyStringTz(subject, "2016-05-02T08:18:18.123", "2016-05-02T12:18:18.123Z", "America/Caracas");
+        for (Map.Entry<String, String> entry : testElements.entrySet()) {
+            applyStringTz(subject, entry.getKey(), entry.getValue(), "America/Caracas");
+        }
     }
 
     @Test

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -69,20 +69,28 @@ public class DateFilterTest {
 
     @Test
     public void testIsoStringsInterpolateTz() throws Exception {
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z");
-            put("1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z");
-            put("2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z");
-            // Venezuela changed from -4:00 to -4:30 in late 2007
-            put("2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z");
-            // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
-            put("2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z");
-        }};
+//        Map<String, String> testElements = new HashMap<String, String>() {{
+//            put("2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z");
+//            put("1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z");
+//            put("2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z");
+//            // Venezuela changed from -4:00 to -4:30 in late 2007
+//            put("2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z");
+//            // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
+//            put("2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z");
+//        }};
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("ISO8601", loc, "%{mytz}");
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyStringTz(subject, entry.getKey(), entry.getValue(), "America/Caracas");
-        }
+//        for (Map.Entry<String, String> entry : testElements.entrySet()) {
+//            applyStringTz(subject, entry.getKey(), entry.getValue(), "America/Caracas");
+//        }
+        applyStringTz(subject, "2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z", "America/Caracas");
+        applyStringTz(subject, "1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z", "America/Caracas");
+        applyStringTz(subject, "2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z", "America/Caracas");
+        // Venezuela changed from -4:00 to -4:30 in late 2007
+        applyStringTz(subject, "2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z", "America/Caracas");
+        // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
+        applyStringTz(subject, "2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z", "America/Caracas");
+//        applyStringTz(subject, "2016-05-02T08:18:18.123", "2016-05-02T12:18:18.123Z", "America/Caracas");
     }
 
     @Test


### PR DESCRIPTION
Joda Time `2.8.2` is from 2015 and doesn't take into account the update of Venezuela's time zone happened in 2016 when it switched from -4:30 CET to  -4:00 CET. This fixes the [test](https://github.com/logstash-plugins/logstash-filter-date/blob/cb7db481e8fe887b63006e660d7a8530e020f999/src/test/java/org/logstash/filters/DateFilterTest.java#L79)