### PR TITLE
Removes for loop on an Map in tests

### DIFF
--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -54,6 +54,20 @@ public class DateFilterTest {
     }
 
     @Test
+    public void testPatternStringsInterpolateTzNoYearFailsOnNotExistingTime() {
+        TestClock clk = new TestClock(new DateTime(2016,03,29,23,59,50, DateTimeZone.UTC ));
+        JodaParser.setDefaultClock(clk);
+        DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
+        subject.acceptFilterConfig("MMM dd hh:mm:ss.SSS", loc, "%{mytz}");
+        // Verify
+        Event event = new Event();
+        event.setField("[happened_at]", "Mar 27 02:00:01.000");
+        event.setField("mytz", "CET");
+        ParseExecutionResult code = subject.executeParsers(event);
+        Assert.assertSame(ParseExecutionResult.FAIL, code);
+    }
+
+    @Test
     public void testIsoStringsInterpolateTz() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("ISO8601", loc, "%{mytz}");

--- a/src/test/java/org/logstash/filters/DateFilterTest.java
+++ b/src/test/java/org/logstash/filters/DateFilterTest.java
@@ -9,9 +9,7 @@ import org.logstash.Timestamp;
 import org.logstash.filters.parser.JodaParser;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,117 +31,79 @@ public class DateFilterTest {
     }
 
     @Test
-    public void testIsoStrings() throws Exception {
-
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("2001-01-01T00:00:00-0800", "2001-01-01T08:00:00.000Z");
-            put("1974-03-02T04:09:09-0800", "1974-03-02T12:09:09.000Z");
-            put("2010-05-03T08:18:18+00:00", "2010-05-03T08:18:18.000Z");
-            put("2004-07-04T12:27:27-00:00", "2004-07-04T12:27:27.000Z");
-            put("2001-09-05T16:36:36+0000", "2001-09-05T16:36:36.000Z");
-            put("2001-11-06T20:45:45-0000", "2001-11-06T20:45:45.000Z");
-            put("2001-12-07T23:54:54Z", "2001-12-07T23:54:54.000Z");
-        }};
+    public void testIsoStrings() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("ISO8601", loc, tz);
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyString(subject, entry.getKey(), entry.getValue());
-        }
+        applyString(subject, "2001-01-01T00:00:00-0800", "2001-01-01T08:00:00.000Z");
+        applyString(subject, "1974-03-02T04:09:09-0800", "1974-03-02T12:09:09.000Z");
+        applyString(subject, "2010-05-03T08:18:18+00:00", "2010-05-03T08:18:18.000Z");
+        applyString(subject, "2004-07-04T12:27:27-00:00", "2004-07-04T12:27:27.000Z");
+        applyString(subject, "2001-09-05T16:36:36+0000", "2001-09-05T16:36:36.000Z");
+        applyString(subject, "2001-11-06T20:45:45-0000", "2001-11-06T20:45:45.000Z");
+        applyString(subject, "2001-12-07T23:54:54Z", "2001-12-07T23:54:54.000Z");
     }
 
     @Test
-    public void testPatternStringsInterpolateTzNoYear() throws Exception {
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("Mar 27 01:59:59.999", "2016-03-27T00:59:59.999Z");
-//            put("Mar 27 02:00:01.000", "2016-03-27T01:00:01.000Z"); // this should and does fail, the time does not exist
-            put("Mar 27 03:00:01.000", "2016-03-27T01:00:01.000Z"); // after CET to CEST change at 02:00
-        }};
+    public void testPatternStringsInterpolateTzNoYear() {
         TestClock clk = new TestClock(new DateTime(2016,03,29,23,59,50, DateTimeZone.UTC ));
         JodaParser.setDefaultClock(clk);
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("MMM dd hh:mm:ss.SSS", loc, "%{mytz}");
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyStringTz(subject, entry.getKey(), entry.getValue(), "CET");
-        }
+        applyStringTz(subject, "Mar 27 01:59:59.999", "2016-03-27T00:59:59.999Z", "CET");
+        applyStringTz(subject, "Mar 27 03:00:01.000", "2016-03-27T01:00:01.000Z", "CET"); // after CET to CEST change at 02:00
     }
 
     @Test
-    public void testIsoStringsInterpolateTz() throws Exception {
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z");
-            put("1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z");
-            put("2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z");
-            // Venezuela changed from -4:00 to -4:30 in late 2007
-            put("2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z");
-            // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
-            put("2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z");
-        }};
+    public void testIsoStringsInterpolateTz() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("ISO8601", loc, "%{mytz}");
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyStringTz(subject, entry.getKey(), entry.getValue(), "America/Caracas");
-        }
+        applyStringTz(subject, "2001-01-01T00:00:00", "2001-01-01T04:00:00.000Z", "America/Caracas");
+        applyStringTz(subject, "1974-03-02T04:09:09", "1974-03-02T08:09:09.000Z", "America/Caracas");
+        applyStringTz(subject, "2006-01-01T00:00:00", "2006-01-01T04:00:00.000Z", "America/Caracas");
+        // Venezuela changed from -4:00 to -4:30 in late 2007
+        applyStringTz(subject, "2008-01-01T00:00:00", "2008-01-01T04:30:00.000Z", "America/Caracas");
+        // Venezuela changed from -4:30 to -4:00 on Sunday, 1 May 2016
+        applyStringTz(subject, "2016-05-01T08:18:18.123", "2016-05-01T12:18:18.123Z", "America/Caracas");
     }
 
     @Test
-    public void testTai64Strings() throws Exception {
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("4000000050d506482dbdf024", "2012-12-22T01:00:46.767Z");
-            put("@4000000050d506482dbdf024", "2012-12-22T01:00:46.767Z");
-
-        }};
+    public void testTai64Strings() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("TAI64N", loc, tz);
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyString(subject, entry.getKey(), entry.getValue());
-        }
+        applyString(subject, "4000000050d506482dbdf024", "2012-12-22T01:00:46.767Z");
+        applyString(subject, "@4000000050d506482dbdf024", "2012-12-22T01:00:46.767Z");
     }
 
     @Test
-    public void testUnixStrings() throws Exception {
-        Map<String, String> testElements = new HashMap<String, String>() {{
-            put("0", "1970-01-01T00:00:00.000Z");
-            put("1000000000", "2001-09-09T01:46:40.000Z");
-            put("1478207457", "2016-11-03T21:10:57.000Z");
-        }};
+    public void testUnixStrings() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
-        for (Map.Entry<String, String> entry : testElements.entrySet()) {
-            applyString(subject, entry.getKey(), entry.getValue());
-        }
+        applyString(subject, "0", "1970-01-01T00:00:00.000Z");
+        applyString(subject, "1000000000", "2001-09-09T01:46:40.000Z");
+        applyString(subject, "1478207457", "2016-11-03T21:10:57.000Z");
     }
     @Test
-    public void testUnixInts() throws Exception {
-        Map<Integer, String> testElements = new HashMap<Integer, String>() {{
-            put(0, "1970-01-01T00:00:00.000Z");
-            put(1000000000, "2001-09-09T01:46:40.000Z");
-            put(1478207457, "2016-11-03T21:10:57.000Z");
-            put(456, "1970-01-01T00:07:36.000Z");
-        }};
+    public void testUnixInts() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
-        for (Map.Entry<Integer, String> entry : testElements.entrySet()) {
-            applyInt(subject, entry.getKey(), entry.getValue());
-        }
+        applyInt(subject, 0, "1970-01-01T00:00:00.000Z");
+        applyInt(subject, 1000000000, "2001-09-09T01:46:40.000Z");
+        applyInt(subject, 1478207457, "2016-11-03T21:10:57.000Z");
+        applyInt(subject, 456, "1970-01-01T00:07:36.000Z");
     }
 
     @Test
-    public void testUnixLongs() throws Exception {
-        Map<Long, String> testElements = new HashMap<Long, String>() {{
-            put(0L, "1970-01-01T00:00:00.000Z");
-            put(1000000000L, "2001-09-09T01:46:40.000Z");
-            put(1478207457L, "2016-11-03T21:10:57.000Z");
-            put(456L, "1970-01-01T00:07:36.000Z");
-        }};
+    public void testUnixLongs() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
-        for (Map.Entry<Long, String> entry : testElements.entrySet()) {
-            applyLong(subject, entry.getKey(), entry.getValue());
-        }
+        applyLong(subject, 0L, "1970-01-01T00:00:00.000Z");
+        applyLong(subject, 1000000000L, "2001-09-09T01:46:40.000Z");
+        applyLong(subject, 1478207457L, "2016-11-03T21:10:57.000Z");
+        applyLong(subject, 456L, "1970-01-01T00:07:36.000Z");
     }
 
     @Test
-    public void testUnixMillisLong() throws Exception {
+    public void testUnixMillisLong() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
         subject.acceptFilterConfig("UNIX_MS", loc, tz);
@@ -151,14 +111,14 @@ public class DateFilterTest {
     }
 
     @Test
-    public void testUnixDouble() throws Exception {
+    public void testUnixDouble() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
         applyDouble(subject, 1478207457.456D, "2016-11-03T21:10:57.456Z");
     }
 
     @Test
-    public void testCancelledEvent() throws Exception {
+    public void testCancelledEvent() {
         DateFilter subject = new DateFilter("[happened_at]", "[result_ts]", failtagList);
         subject.acceptFilterConfig("UNIX", loc, tz);
 


### PR DESCRIPTION
Verifying conditions in loop is not helpful if a failure happens, because doesn't provide any insight on which loop it failed, and the reported line doesn't point directly to the problem.

This PR unroll loops to have a more effective error when test fails.