### PR TITLE
Fix deprecation warning and test time error

### DIFF
--- a/src/main/java/org/logstash/filters/DateFilter.java
+++ b/src/main/java/org/logstash/filters/DateFilter.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DateFilter {
-  private static Logger logger = LogManager.getLogger();
+  private static Logger logger = LogManager.getLogger(DateFilter.class);
   private final String sourceField;
   private final String[] tagOnFailure;
   private RubyResultHandler successHandler;

--- a/src/test/java/org/logstash/filters/parser/UnixEpochParserTest.java
+++ b/src/test/java/org/logstash/filters/parser/UnixEpochParserTest.java
@@ -43,7 +43,7 @@ public class UnixEpochParserTest {
 
     // Create a random number of values to test
     return LongStream.range(1, count)
-            .map(i -> new Long(Math.abs(random.nextLong() % Integer.MAX_VALUE)))
+            .map(i -> Math.abs(random.nextLong() % Integer.MAX_VALUE))
             .mapToObj(i -> new Object[] { new Instant(i), String.format("%d.%03d", i / 1000, i % 1000) })
             .collect(Collectors.toList());
   }


### PR DESCRIPTION
Avoid to use the Long constructor and avoid autoboxing plus fix usage of getLogger().

The usage of [`getLogger()`](https://github.com/logstash-plugins/logstash-filter-date/blob/cc31a74cad2dcc971525f691b8892e65cd723449/src/main/java/org/logstash/filters/DateFilter.java#L37) without a class parameter generates the following test time error:
```
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.

java.lang.ExceptionInInitializerError
	at org.logstash.filters.DateFilterTest.testUnixMillisLong(DateFilterTest.java:121)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.UnsupportedOperationException: No class provided, and an appropriate one cannot be found.
	at org.apache.logging.log4j.LogManager.callerClass(LogManager.java:555)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:580)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:567)
	at org.logstash.filters.DateFilter.<clinit>(DateFilter.java:37)
	... 41 more
```