### PR TITLE
Fix unit tests when default timezone is not UTC

### DIFF
--- a/spec/filters/date_spec.rb
+++ b/spec/filters/date_spec.rb
@@ -820,7 +820,7 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
   end
 
   describe "cancelled events" do
-    subject { described_class.new("match" => [ "message", "yyyy" ]) }
+    subject { described_class.new("match" => [ "message", "yyyy" ], "timezone" => "UTC") }
 
     context "single cancelled event" do
       let(:event) do

--- a/src/main/java/org/logstash/filters/DateFilter.java
+++ b/src/main/java/org/logstash/filters/DateFilter.java
@@ -72,7 +72,7 @@ public class DateFilter {
     }
   }
 
- public List<RubyEvent> receive(List<RubyEvent> rubyEvents) {
+  public List<RubyEvent> receive(List<RubyEvent> rubyEvents) {
     for (RubyEvent rubyEvent : rubyEvents) {
       Event event = rubyEvent.getEvent();
 


### PR DESCRIPTION
Fixes ruby unit test in case the running host has a default timezone different than UTC, configuring the plugin to use UTC timezone.

Without specifying the timezone in the test, it brings the default from the system. The extraction of year from Logstash's Timestamp is done in UTC [timezone](https://github.com/elastic/logstash/blob/080c2f625317d7e20a8a5841db3d261c07ad7eb6/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java#L252-L257): 
```java
final int year = this.timestamp.toInstant().atOffset(java.time.ZoneOffset.UTC).getYear();
```

Creating a timestamp in a timezone different from UTC generates the error:
```sh
Failures:

  1) LogStash::Filters::Date cancelled events cancelled events list ignores and return ignored cancelled
     Failure/Error: expect(result[2].timestamp.year).to eq(uncancelled_year)
     
       expected: 2001
            got: 2000
     
       (compared using ==)
     # ./spec/filters/date_spec.rb:871:in `block in <main>'
     # /usr/share/rvm/gems/jruby-9.2.9.0/gems/logstash-devutils-2.4.0-java/lib/logstash/devutils/rspec/spec_helper.rb:61:in `block in <main>'

Finished in 0.16188 seconds (files took 3.09 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/filters/date_spec.rb:862 # LogStash::Filters::Date cancelled events cancelled events list ignores and return ignored cancelled
```


# How to test
- setup an enviroment with 
```
export LOGSTASH_PATH= && export LOGSTASH_SOURCE=1
```
- check your default timezone differs from UTC
- run the test
```
bundler exec rspec spec/filters/date_spec.rb:862
```
- on `main` must fail while in this branch success.