### PR TITLE
Retrieve logstash-core gem's path using inline bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,9 @@ end
 file "gradle.properties" do
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  lsc_path = `bundle show logstash-core`
+  # Use same JRuby that launched this Rake
+  current_ruby_path = RbConfig::CONFIG['prefix']
+  lsc_path = `#{current_ruby_path}/bin/jruby -S bundle show logstash-core`
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|
     f.puts "logstashCoreGemPath=#{lsc_path}"

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,8 @@ end
 file "gradle.properties" do
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  # Use same JRuby that launched this Rake
-  current_ruby_path = RbConfig::CONFIG['prefix']
-  lsc_path = `#{current_ruby_path}/bin/jruby -S bundle show logstash-core`
+  # find the path to the logstash-core gem
+  lsc_path = Bundler.rubygems.find_name("logstash-core").first.full_gem_path
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|
     f.puts "logstashCoreGemPath=#{lsc_path}"


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Avoid to fork a bundler process to extract `logstash-core`'s path and use the same bundler that wraps the execution of the Rakefile itself.

## Why is it important/What is the impact to the user?

All the Rake tasks must run with same JRuby distribution that launched the execution. Without this, it uses the system's Ruby.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run with system's JRuby
- [x] run with not the system's JRuby

## How to test this PR locally

Verify that it works with Logstash JRuby distribution:
```sh
export LOGSTASH_PATH=/tmp/logstash/ && export LOGSTASH_SOURCE=1
/tmp/logstash/bin/ruby -S bundle install
/tmp/logstash/bin/ruby -S exec rake vendor
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #159 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
If not configured int his way, running `/tmp/logstash/bin/ruby -S exec rake vendor` would rise:
```
andrea:logstash-filter-date (main) % rm gradle.properties && /tmp/logstash/bin/ruby -S bundle exec rake vendor
Using system java: /Users/andrea/.sdkman/candidates/java/current/bin/java
Processing jvm.options file at `/tmp/logstash/config/jvm.options`
Using GEM_HOME=/tmp/logstash/vendor/bundle/jruby/3.1.0
Using GEM_PATH=/tmp/logstash/vendor/bundle/jruby/3.1.0
DEBUG: exec /tmp/logstash/vendor/jruby/bin/jruby -S bundle exec rake vendor

Gem::GemNotFoundException: can't find gem bundler (= 2.3.26) with executable bundle
       find_spec_for_exe at /Users/andrea/.rvm/rubies/jruby-9.4.2.0/lib/ruby/stdlib/rubygems.rb:265
                bin_path at /Users/andrea/.rvm/rubies/jruby-9.4.2.0/lib/ruby/stdlib/rubygems.rb:245
                bin_path at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_integration.rb:178
    set_bundle_variables at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/shared_helpers.rb:282
  set_bundle_environment at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/shared_helpers.rb:76
                   setup at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/runtime.rb:20
                   setup at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler.rb:161
                  <main> at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/setup.rb:20
              with_level at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/ui/shell.rb:136
                 silence at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/ui/shell.rb:88
                  <main> at /tmp/logstash/vendor/jruby/lib/ruby/stdlib/bundler/setup.rb:20
                 require at org/jruby/RubyKernel.java:1057
                 require at /Users/andrea/.rvm/rubies/jruby-9.4.2.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85
-------------------> Wrote /Users/andrea/workspace/logstash_plugins/logstash-filter-date/gradle.properties
logstashCoreGemPath=
```