### PR TITLE
Fix date syntax docs list formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Fix date syntax docs list formatting [#166](https://github.com/logstash-plugins/logstash-filter-date/pull/166)
+
 ## 3.2.0
   - Add `precision` setting to support nanosecond precision timestamps [#165](https://github.com/logstash-plugins/logstash-filter-date/pull/165)
     - `ms` (default): timestamps are stored with millisecond precision

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -111,61 +111,60 @@ indicate the form of that value (2-digit month, full month name, etc).
 
 Here's what you can use to parse dates and times:
 
-[horizontal]
-y:: year
-  yyyy::: full year number. Example: `2015`.
-  yy::: two-digit year. Example: `15` for the year 2015.
+* `y`: year
+** `yyyy`: full year number. Example: `2015`.
+** `yy`: two-digit year. Example: `15` for the year 2015.
 
-M:: month of the year
-  M::: minimal-digit month. Example: `1` for January and `12` for December.
-  MM::: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
-  MMM::: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
-  MMMM::: full month text, Example: `January`. Note: The language used depends on your locale.
+* `M`: month of the year
+** `M`: minimal-digit month. Example: `1` for January and `12` for December.
+** `MM`: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
+** `MMM`: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
+** `MMMM`: full month text, Example: `January`. Note: The language used depends on your locale.
 
-d:: day of the month
-  d::: minimal-digit day. Example: `1` for the 1st of the month.
-  dd::: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
+* `d`: day of the month
+** `d`: minimal-digit day. Example: `1` for the 1st of the month.
+** `dd`: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
 
-H:: hour of the day (24-hour clock)
-  H::: minimal-digit hour. Example: `0` for midnight.
-  HH::: two-digit hour, zero-padded if needed. Example: `00` for midnight.
+* `H`: hour of the day (24-hour clock)
+** `H`: minimal-digit hour. Example: `0` for midnight.
+** `HH`: two-digit hour, zero-padded if needed. Example: `00` for midnight.
 
-m:: minutes of the hour (60 minutes per hour)
-  m::: minimal-digit minutes. Example: `0`.
-  mm::: two-digit minutes, zero-padded if needed. Example: `00`.
+* `m`: minutes of the hour (60 minutes per hour)
+** `m`: minimal-digit minutes. Example: `0`.
+** `mm`: two-digit minutes, zero-padded if needed. Example: `00`.
 
-s:: seconds of the minute (60 seconds per minute)
-  s::: minimal-digit seconds. Example: `0`.
-  ss::: two-digit seconds, zero-padded if needed. Example: `00`.
+* `s`: seconds of the minute (60 seconds per minute)
+** `s`: minimal-digit seconds. Example: `0`.
+** `ss`: two-digit seconds, zero-padded if needed. Example: `00`.
 
-S:: fraction of a second
-  S::: tenths of a second. Example:  `0` for a subsecond value `012`
-  SS::: hundredths of a second. Example:  `01` for a subsecond value `01`
-  SSS::: milliseconds. Example:  `012` for a subsecond value `012`
-  SSSSSS::: microseconds. Example:  `012345`
-  SSSSSSSSS::: nanoseconds. Example:  `012345678`
+* `S`: fraction of a second
+** `S`: tenths of a second. Example:  `0` for a subsecond value `012`
+** `SS`: hundredths of a second. Example:  `01` for a subsecond value `01`
+** `SSS`: milliseconds. Example:  `012` for a subsecond value `012`
+** `SSSSSS`: microseconds. Example:  `012345`
+** `SSSSSSSSS`: nanoseconds. Example:  `012345678`
 
-V:: time-zone ID
-  VV::: time zone ID. Example: `America/Los_Angeles`. Note: This is only supported by `java.time` parsing.
+* `V`: time-zone ID
+** `VV`: time zone ID. Example: `America/Los_Angeles`. Note: This is only supported by `java.time` parsing.
 
-Z:: time zone offset or identity
-  Z::: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
-  ZZ::: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
-  ZZZ::: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
+* `Z`: time zone offset or identity
+** `Z`: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
+** `ZZ`: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
+** `ZZZ`: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
 
-z:: time zone names. *Time zone names ('z') cannot be parsed.*
+* `z`: time zone names. *Time zone names (`z`) cannot be parsed.*
 
-w:: week of the year
-  w::: minimal-digit week. Example: `1`.
-  ww::: two-digit week, zero-padded if needed. Example: `01`.
+* `w`: week of the year
+** `w`: minimal-digit week. Example: `1`.
+** `ww`: two-digit week, zero-padded if needed. Example: `01`.
 
-D:: day of the year
+* `D`: day of the year
 
-e:: day of the week (number)
+* `e`: day of the week (number)
 
-E:: day of the week (text)
-  E, EE, EEE::: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
-  EEEE::: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
+* `E`: day of the week (text)
+** `E`, `EE`, `EEE`: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
+** `EEEE`: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
 
 For non-formatting syntax, you'll need to put single-quote characters around the value. For example, if you were parsing ISO8601 time, "2015-01-01T01:12:23" that little "T" isn't a valid time format, and you want to say "literally, a T", your format would be this: "yyyy-MM-dd'T'HH:mm:ss"
 

--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -83,58 +83,57 @@ class LogStash::Filters::Date < LogStash::Filters::Base
   #
   # Here's what you can use to parse dates and times:
   #
-  # [horizontal]
-  # y:: year
-  #   yyyy::: full year number. Example: `2015`.
-  #   yy::: two-digit year. Example: `15` for the year 2015.
+  # * `y`: year
+  # ** `yyyy`: full year number. Example: `2015`.
+  # ** `yy`: two-digit year. Example: `15` for the year 2015.
   #
-  # M:: month of the year
-  #   M::: minimal-digit month. Example: `1` for January and `12` for December.
-  #   MM::: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
-  #   MMM::: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
-  #   MMMM::: full month text, Example: `January`. Note: The language used depends on your locale.
+  # * `M`: month of the year
+  # ** `M`: minimal-digit month. Example: `1` for January and `12` for December.
+  # ** `MM`: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
+  # ** `MMM`: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
+  # ** `MMMM`: full month text, Example: `January`. Note: The language used depends on your locale.
   #
-  # d:: day of the month
-  #   d::: minimal-digit day. Example: `1` for the 1st of the month.
-  #   dd::: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
+  # * `d`: day of the month
+  # ** `d`: minimal-digit day. Example: `1` for the 1st of the month.
+  # ** `dd`: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
   #
-  # H:: hour of the day (24-hour clock)
-  #   H::: minimal-digit hour. Example: `0` for midnight.
-  #   HH::: two-digit hour, zero-padded if needed. Example: `00` for midnight.
+  # * `H`: hour of the day (24-hour clock)
+  # ** `H`: minimal-digit hour. Example: `0` for midnight.
+  # ** `HH`: two-digit hour, zero-padded if needed. Example: `00` for midnight.
   #
-  # m:: minutes of the hour (60 minutes per hour)
-  #   m::: minimal-digit minutes. Example: `0`.
-  #   mm::: two-digit minutes, zero-padded if needed. Example: `00`.
+  # * `m`: minutes of the hour (60 minutes per hour)
+  # ** `m`: minimal-digit minutes. Example: `0`.
+  # ** `mm`: two-digit minutes, zero-padded if needed. Example: `00`.
   #
-  # s:: seconds of the minute (60 seconds per minute)
-  #   s::: minimal-digit seconds. Example: `0`.
-  #   ss::: two-digit seconds, zero-padded if needed. Example: `00`.
+  # * `s`: seconds of the minute (60 seconds per minute)
+  # ** `s`: minimal-digit seconds. Example: `0`.
+  # ** `ss`: two-digit seconds, zero-padded if needed. Example: `00`.
   #
-  # S:: fraction of a second
-  #   S::: tenths of a second. Example:  `0` for a subsecond value `012`
-  #   SS::: hundredths of a second. Example:  `01` for a subsecond value `01`
-  #   SSS::: milliseconds. Example:  `012` for a subsecond value `012`
-  #   SSSSSS::: microseconds.
-  #   SSSSSSSSS::: nanoseconds.
+  # * `S`: fraction of a second
+  # ** `S`: tenths of a second. Example:  `0` for a subsecond value `012`
+  # ** `SS`: hundredths of a second. Example:  `01` for a subsecond value `01`
+  # ** `SSS`: milliseconds. Example:  `012` for a subsecond value `012`
+  # ** `SSSSSS`: microseconds.
+  # ** `SSSSSSSSS`: nanoseconds.
   #
-  # Z:: time zone offset or identity
-  #   Z::: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
-  #   ZZ::: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
-  #   ZZZ::: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
+  # * `Z`: time zone offset or identity
+  # ** `Z`: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
+  # ** `ZZ`: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
+  # ** `ZZZ`: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
   #
-  # z:: time zone names. *Time zone names ('z') cannot be parsed.*
+  # * `z`: time zone names. *Time zone names (`z`) cannot be parsed.*
   #
-  # w:: week of the year
-  #   w::: minimal-digit week. Example: `1`.
-  #   ww::: two-digit week, zero-padded if needed. Example: `01`.
+  # * `w`: week of the year
+  # ** `w`: minimal-digit week. Example: `1`.
+  # ** `ww`: two-digit week, zero-padded if needed. Example: `01`.
   #
-  # D:: day of the year
+  # * `D`: day of the year
   #
-  # e:: day of the week (number)
+  # * `e`: day of the week (number)
   #
-  # E:: day of the week (text)
-  #   E, EE, EEE::: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
-  #   EEEE::: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
+  # * `E`: day of the week (text)
+  # ** `E`, `EE`, `EEE`: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
+  # ** `EEEE`: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
   #
   # For non-formatting syntax, you'll need to put single-quote characters around the value. For example, if you were parsing ISO8601 time, "2015-01-01T01:12:23" that little "T" isn't a valid time format, and you want to say "literally, a T", your format would be this: "yyyy-MM-dd'T'HH:mm:ss"
   #

--- a/logstash-filter-date.gemspec
+++ b/logstash-filter-date.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-date'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses dates from fields to use as the Logstash timestamp for an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/fixtures/old_date_filter.rb
+++ b/spec/fixtures/old_date_filter.rb
@@ -92,57 +92,56 @@ class LogStash::Filters::DateRuby < LogStash::Filters::Base
   #
   # Here's what you can use to parse dates and times:
   #
-  # [horizontal]
-  # y:: year
-  #   yyyy::: full year number. Example: `2015`.
-  #   yy::: two-digit year. Example: `15` for the year 2015.
+  # * `y`: year
+  # ** `yyyy`: full year number. Example: `2015`.
+  # ** `yy`: two-digit year. Example: `15` for the year 2015.
   #
-  # M:: month of the year
-  #   M::: minimal-digit month. Example: `1` for January and `12` for December.
-  #   MM::: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
-  #   MMM::: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
-  #   MMMM::: full month text, Example: `January`. Note: The language used depends on your locale.
+  # * `M`: month of the year
+  # ** `M`: minimal-digit month. Example: `1` for January and `12` for December.
+  # ** `MM`: two-digit month. zero-padded if needed. Example: `01` for January  and `12` for December
+  # ** `MMM`: abbreviated month text. Example: `Jan` for January. Note: The language used depends on your locale. See the `locale` setting for how to change the language.
+  # ** `MMMM`: full month text, Example: `January`. Note: The language used depends on your locale.
   #
-  # d:: day of the month
-  #   d::: minimal-digit day. Example: `1` for the 1st of the month.
-  #   dd::: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
+  # * `d`: day of the month
+  # ** `d`: minimal-digit day. Example: `1` for the 1st of the month.
+  # ** `dd`: two-digit day, zero-padded if needed. Example: `01` for the 1st of the month.
   #
-  # H:: hour of the day (24-hour clock)
-  #   H::: minimal-digit hour. Example: `0` for midnight.
-  #   HH::: two-digit hour, zero-padded if needed. Example: `00` for midnight.
+  # * `H`: hour of the day (24-hour clock)
+  # ** `H`: minimal-digit hour. Example: `0` for midnight.
+  # ** `HH`: two-digit hour, zero-padded if needed. Example: `00` for midnight.
   #
-  # m:: minutes of the hour (60 minutes per hour)
-  #   m::: minimal-digit minutes. Example: `0`.
-  #   mm::: two-digit minutes, zero-padded if needed. Example: `00`.
+  # * `m`: minutes of the hour (60 minutes per hour)
+  # ** `m`: minimal-digit minutes. Example: `0`.
+  # ** `mm`: two-digit minutes, zero-padded if needed. Example: `00`.
   #
-  # s:: seconds of the minute (60 seconds per minute)
-  #   s::: minimal-digit seconds. Example: `0`.
-  #   ss::: two-digit seconds, zero-padded if needed. Example: `00`.
+  # * `s`: seconds of the minute (60 seconds per minute)
+  # ** `s`: minimal-digit seconds. Example: `0`.
+  # ** `ss`: two-digit seconds, zero-padded if needed. Example: `00`.
   #
-  # S:: fraction of a second
-  #   *Maximum precision is milliseconds (`SSS`). Beyond that, zeroes are appended.*
-  #   S::: tenths of a second. Example:  `0` for a subsecond value `012`
-  #   SS::: hundredths of a second. Example:  `01` for a subsecond value `01`
-  #   SSS::: thousandths of a second. Example:  `012` for a subsecond value `012`
+  # * `S`: fraction of a second
+  # ** Maximum precision is milliseconds (`SSS`). Beyond that, zeroes are appended.
+  # ** `S`: tenths of a second. Example:  `0` for a subsecond value `012`
+  # ** `SS`: hundredths of a second. Example:  `01` for a subsecond value `01`
+  # ** `SSS`: thousandths of a second. Example:  `012` for a subsecond value `012`
   #
-  # Z:: time zone offset or identity
-  #   Z::: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
-  #   ZZ::: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
-  #   ZZZ::: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
+  # * `Z`: time zone offset or identity
+  # ** `Z`: Timezone offset structured as HHmm (hour and minutes offset from Zulu/UTC). Example: `-0700`.
+  # ** `ZZ`: Timezone offset structured as HH:mm (colon in between hour and minute offsets). Example: `-07:00`.
+  # ** `ZZZ`: Timezone identity. Example: `America/Los_Angeles`. Note: Valid IDs are listed on the http://joda-time.sourceforge.net/timezones.html[Joda.org available time zones page].
   #
-  # z:: time zone names. *Time zone names ('z') cannot be parsed.*
+  # * `z`: time zone names. *Time zone names (`z`) cannot be parsed.*
   #
-  # w:: week of the year
-  #   w::: minimal-digit week. Example: `1`.
-  #   ww::: two-digit week, zero-padded if needed. Example: `01`.
+  # * `w`: week of the year
+  # ** `w`: minimal-digit week. Example: `1`.
+  # ** `ww`: two-digit week, zero-padded if needed. Example: `01`.
   #
-  # D:: day of the year
+  # * `D`: day of the year
   #
-  # e:: day of the week (number)
+  # * `e`: day of the week (number)
   #
-  # E:: day of the week (text)
-  #   E, EE, EEE::: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
-  #   EEEE::: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
+  # * `E`: day of the week (text)
+  # ** `E`, `EE`, `EEE`: Abbreviated day of the week. Example:  `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`. Note: The actual language of this will depend on your locale.
+  # ** `EEEE`: The full text day of the week. Example: `Monday`, `Tuesday`, ... Note: The actual language of this will depend on your locale.
   #
   # For non-formatting syntax, you'll need to put single-quote characters around the value. For example, if you were parsing ISO8601 time, "2015-01-01T01:12:23" that little "T" isn't a valid time format, and you want to say "literally, a T", your format would be this: "yyyy-MM-dd'T'HH:mm:ss"
   #


### PR DESCRIPTION
## Summary
- Replaces the nested `[horizontal]` date syntax description list with nested bullets so generated Markdown keeps `V`/`VV` and `Z`/`ZZ`/`ZZZ` entries separate.
- Updates the matching Ruby doc comments and old fixture comments to avoid reintroducing the same markup through doc generation paths.

## Related issue
- Addresses elastic/docs-content#6030.

## Test plan
- Ran `ruby -c lib/logstash/filters/date.rb`.
- Ran `ruby -c spec/fixtures/old_date_filter.rb`.
- Confirmed no `[horizontal]` or nested `:::` markup remains in this repository.
- Asciidoctor rendering was not run locally because the `asciidoctor` gem is not installed in the local Ruby environment.

Made with [Cursor](https://cursor.com)